### PR TITLE
商品詳細ページの表示の実装

### DIFF
--- a/app/assets/stylesheets/modules/_items_details-page.scss
+++ b/app/assets/stylesheets/modules/_items_details-page.scss
@@ -230,6 +230,40 @@
               }
             }
           }
+          .item{
+            &--edit__btn{
+            max-width:380px;
+            text-align:center;
+            margin:40px auto;
+              .link__btn{
+                @include required(16px,60px);
+                width:100%;
+              }
+            }
+            &--pause__btn{
+            max-width:380px;
+            text-align:center;
+            margin:40px auto;
+            .un--link__btn{
+              @include unrequired(16px,60px);
+              width:100%;
+              }
+            }
+            &--delete__btn{
+            max-width:380px;
+            text-align:center;
+            margin:40px auto;
+            .un--link__btn{
+              @include unrequired(16px,60px);
+              width:100%;
+              }
+            }
+          }
+          p{
+            display:block;
+            text-align:center;
+            font-size:16px;
+          }
           .purchase__btn{
             max-width:380px;
             text-align:center;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -104,7 +104,18 @@
                 = link_to '#' do
                   =icon('fa','flag')
                   不適切な商品の通報
-        - unless current_user == @item.user.id
+        - if current_user.id == @item.user.id
+          %section.item--edit__btn
+            = link_to '#', class: 'link__btn' do
+              商品の編集
+          %p or
+          %section.item--pause__btn
+            = link_to '#', class: 'un--link__btn' do
+              商品の出品を一旦停止する
+          %section.item--delete__btn
+            = link_to '#', class: 'un--link__btn' do
+              この商品を削除する
+        - else
           %section.purchase__btn
             = link_to purchase_item_path, class: 'link__btn' do
               購入する


### PR DESCRIPTION
WHAT
商品詳細ページの表示の実装

出品者→商品編集できる
閲覧者→購入ボタンの表示

WHY
出品者しか商品編集をできない様にするため

出品物の場合

![demo](https://gyazo.com/528d41ec44dbad2b964c8a1ae9233829/raw)

出品物でない場合

![demo](https://gyazo.com/2f91a1c3aa3d7ec8fa27cf1b0fe47f9b/raw)