### PR TITLE
商品詳細ページの表示の変更

### DIFF
--- a/app/assets/stylesheets/modules/_items_details-page.scss
+++ b/app/assets/stylesheets/modules/_items_details-page.scss
@@ -140,11 +140,10 @@
                     margin-top:10px;
                     width:560px;
                     &__list{
+                      margin:0 5px 0;
                       width:25%;
-                      margin-right:10px;
                       .sub__image{
                         object-fit:cover;
-                        height:87px;
                         vertical-align:bottom;
                         width:100%;
                       }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -13,17 +13,17 @@
             = icon('fa', 'angle-right')
           %li.my--page__nav__guide--menu__btn
             = link_to '#' do
-              ベビー・キッズ
+              = @item.category.parent.parent.name
           %li.my--page__nav__guide--menu__btn
             = icon('fa', 'angle-right')
           %li.my--page__nav__guide--menu__btn
             = link_to '#' do
-              ベビー服(男女兼用)~95cm
+              = @item.category.parent.name
           %li.my--page__nav__guide--menu__btn
             = icon('fa', 'angle-right')
           %li.my--page__nav__guide--menu__btn
             = link_to '#' do
-              アウター
+              = @item.category.name
           %li.my--page__nav__guide--menu__btn
             = icon('fa', 'angle-right')
           %li.my--page__nav__guide--menu__btn
@@ -67,13 +67,19 @@
                   = @item.user.nickname
               %tr
                 %th カテゴリー
-                %td 
-                  = link_to '#' do
-                    ベビー・キッズ
-                  = link_to '#' do
-                    ベビー服(男女兼用)~95cm
-                  = link_to '#' do
-                    アウター
+                %td
+                  %ul
+                    %li
+                      = link_to '#' do
+                        = @item.category.parent.parent.name
+                    %li
+                      = link_to '#' do
+                        = icon('fa', 'angle-right') 
+                        = @item.category.parent.name
+                    %li
+                      = link_to '#' do
+                        = icon('fa', 'angle-right') 
+                        = @item.category.name
               %tr
                 %th ブランド
                 %td

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -40,17 +40,14 @@
           .top__contents__items__picture
             %ul.main__picture__detail
               %li.main__picture__detail__list 
-                = image_tag 'curry.png', alt: '商品画像1', class: 'main__image'
+                = image_tag @item.pictures.first.image.url, alt: '商品画像(メイン)', class: 'main__image'
                 - unless @item.bought_at == nil
                   .sold--icon
                   .sold--message sold
                 %ul.sub__picture__detail
-                  %li.sub__picture__detail__list
-                    = image_tag 'fish.png', alt: '商品画像2', class: 'sub__image'
-                  %li.sub__picture__detail__list
-                    = image_tag 'curry.png', alt: '商品画像2', class: 'sub__image'
-                  %li.sub__picture__detail__list
-                    = image_tag 'meat.png', alt: '商品画像2', class: 'sub__image'
+                  - @item.pictures.each do |picture|
+                    %li.sub__picture__detail__list
+                      = image_tag picture.image.url, alt: '商品画像(サブ)', class: 'sub__image', height:'72', width:'60'
           .top__contents__items__price
             %span 
               ¥#{@item.price}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2020_05_31_172345) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_cards_on_user_id"
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -126,6 +127,7 @@ ActiveRecord::Schema.define(version: 2020_05_31_172345) do
   end
 
   add_foreign_key "addresses", "users"
+  add_foreign_key "cards", "users"
   add_foreign_key "comments", "items"
   add_foreign_key "comments", "users"
   add_foreign_key "item_tags", "tags"


### PR DESCRIPTION
WHAT
カテゴリーの表示ができる様にした。

WHY
商品がどのカテゴリーなのか一目でわかる様にするため

プレビュー
![demo](https://gyazo.com/3cefdb2da738b3982a2be1e8249a6e1b/raw)


![demo](https://gyazo.com/f47d37ebc980b8b0fa210d1f885a7991/raw)

商品画像1枚
![demo](https://gyazo.com/2f8a2239f1436baa7e58d97a9cc27aaa/raw)

商品画像10枚
![demo](https://gyazo.com/0508fe7d6bbabdf82da47db79ce98c64/raw)