### PR TITLE
住所登録時のエラーメッセージの日本語化とバリデーション修正

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -22,7 +22,6 @@ class Address < ApplicationRecord
   validates :block_number,            presence: true, length: { maximum: 30 }, format: { with: VALID_ZENKAKU_REGEX }
   validates :building,                allow_blank: true, length: { maximum: 30 }, format: { with: VALID_ZENKAKU_REGEX }
   validates :telephone,               allow_blank: true, length: { in: 10..11 }, format: { with: VALID_TELEPHONE_REGEX }
-  validates :user_id,                 presence: true, uniqueness: true
 
   enum prefecture:{
     '---':         0,

--- a/app/views/addresses/_my-page_address-form_edit.html.haml
+++ b/app/views/addresses/_my-page_address-form_edit.html.haml
@@ -55,25 +55,25 @@
             = f.select :prefecture, Address.prefectures.keys.map{|k| [I18n.t("enums.address.prefecture.#{k}"), k]}, {selected: @address.prefecture}
           .address-form__input-info__label
             .address-form__input-info__label__set
-              市区町村
+              市区町村（全角）
             .address-form__input-info__label--required
               必須
           = f.text_field :city, value: @address.city, class: 'address-form__input-info__field'
           .address-form__input-info__label
             .address-form__input-info__label__set
-              番地
+              番地（全角）
             .address-form__input-info__label--required
               必須
           = f.text_field :block_number, value: @address.block_number, class: 'address-form__input-info__field'
           .address-form__input-info__label
             .address-form__input-info__label__set
-              建物名・部屋
+              建物名・部屋（全角）
             .address-form__input-info__label--unrequired
               任意
           = f.text_field :building, value: @address.building, class: 'address-form__input-info__field'
           .address-form__input-info__label
             .address-form__input-info__label__set
-              電話番号（ハイフンなし）
+              電話番号（半角ハイフンなし）
             .address-form__input-info__label--unrequired
               任意
           = f.text_field :telephone, value: @address.telephone, class: 'address-form__input-info__field'

--- a/app/views/users/registrations/new_address.html.haml
+++ b/app/views/users/registrations/new_address.html.haml
@@ -51,25 +51,25 @@
             = f.select :prefecture, Address.prefectures.keys.map{|k| [I18n.t("enums.address.prefecture.#{k}"), k]}
           .address-form__input-info__label
             .address-form__input-info__label__set
-              市区町村
+              市区町村（全角）
             .address-form__input-info__label--required
               必須
           = f.text_field :city, placeholder: "例）渋谷区", class: 'address-form__input-info__field'
           .address-form__input-info__label
             .address-form__input-info__label__set
-              番地
+              番地（全角）
             .address-form__input-info__label--required
               必須
           = f.text_field :block_number, placeholder: "例）渋谷５丁目６−１", class: 'address-form__input-info__field'
           .address-form__input-info__label
             .address-form__input-info__label__set
-              建物名・部屋
+              建物名・部屋（全角）
             .address-form__input-info__label--unrequired
               任意
           = f.text_field :building, placeholder: "例）フリマビル　２０１号室", class: 'address-form__input-info__field'
           .address-form__input-info__label
             .address-form__input-info__label__set
-              電話番号（ハイフンなし）
+              電話番号（半角ハイフンなし）
             .address-form__input-info__label--unrequired
               任意
           = f.text_field :telephone, placeholder: "例）0312345678", class: 'address-form__input-info__field'

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module FreemarketSample70A
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -99,18 +99,6 @@ ja:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
     models:
-      address: "発送元・送付先住所"
-    attributes:
-      address:
-        dest_first_name: 姓
-        dest_last_name: 名
-        dest_first_name_kana: セイ
-        dest_last_name_kana: メイ
-        zip_code: 郵便番号
-        prefecture: 都道府県
-        city: 市区町村
-        block_number: 番地
-    models:
       item: "商品"
     attributes:
       item:

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,14 @@
+ja:
+  activerecord:
+    models:
+      address: "発送元・送付先住所"
+    attributes:
+      address:
+        dest_first_name: 姓
+        dest_last_name: 名
+        dest_first_name_kana: セイ
+        dest_last_name_kana: メイ
+        zip_code: 郵便番号
+        prefecture: 都道府県
+        city: 市区町村
+        block_number: 番地


### PR DESCRIPTION
## What
ウィザード形式での住所登録時のエラーメッセージの日本語化とaddressモデルのバリデーション修正

## Why
エラーメッセージを日本語で表記させるため
Addressモデルのバリデーションエラーが発生してユーザ登録ができないため

### キャプチャ
[![Image from Gyazo](https://i.gyazo.com/096946b39878e18806e953c3342983ab.png)](https://gyazo.com/096946b39878e18806e953c3342983ab)

[![Image from Gyazo](https://i.gyazo.com/c0b1c57c2f86fd2d971f942499d771e3.gif)](https://gyazo.com/c0b1c57c2f86fd2d971f942499d771e3)