### PR TITLE
Fix cardpage

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,33 +1,28 @@
 $(document).on('turbolinks:load', function() {
+  $('#token_submit').on('click', function(e) {
     Payjp.setPublicKey("pk_test_0df3d3eb150a3f3dd0f2fc3e");
-    const btn = document.getElementById('token_submit'); //IDがtoken_submitの場合に取得する
-    btn.addEventListener("click", (e) => {　//ボタンが押されたときに作動させる
-        e.preventDefault();　//ボタンを一旦無効化する
-
-      //カード情報生成
-      const card = {
-        number: document.getElementById("card_number").value,
-        cvc: document.getElementById("cvc").value,
-        exp_month: document.getElementById("exp_month").value,
-        exp_year: document.getElementById("exp_year").value
-      }; //入力されたデータを取得する
-
-      //cardトークン生成
-      Payjp.createToken(card, (status, response) => {
-        if (status === 200) { 
-          $("#card_number").removeAttr("name");
-          $("#cvc").removeAttr("name");
-          $("#exp_month").removeAttr("name");
-          $("#exp_year").removeAttr("name"); //カード情報を自分のサーバにpostせず削除する
-          $("#card_token").append(
-            $('<input hidden name="payjp-token">').val(response.id)
-          ); //トークンを送信できるように隠しタグを生成
-          document.inputForm.submit();
-          alert("登録が完了しました"); 
-        } else {
-          alert("カード情報が正しくありません。");
-        }
-      });
+    e.preventDefault();
+    //カード情報生成
+    const card = {
+      number: document.getElementById("card_number").value,
+      cvc: document.getElementById("cvc").value,
+      exp_month: document.getElementById("exp_month").value,
+      exp_year: document.getElementById("exp_year").value
+    }; //入力されたデータを取得します。
+    //トークン生成
+    Payjp.createToken(card, (status, response) => {
+      if (status === 200) { //成功した場合
+        $("#card_number").removeAttr("name");
+        $("#cvc").removeAttr("name");
+        $("#exp_month").removeAttr("name");
+        $("#exp_year").removeAttr("name"); //カード情報を自分のサーバにpostせず削除します
+        $("#card_token").append(
+          $('<input hidden name="payjp-token">').val(response.id)
+        ); //トークンを送信できるように隠しタグを生成
+        document.inputForm.submit();
+      }
     });
+  });
   false;
 });
+

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,7 +1,7 @@
 $(document).on('turbolinks:load', function() {
   $('#token_submit').on('click', function(e) {
     Payjp.setPublicKey("pk_test_0df3d3eb150a3f3dd0f2fc3e");
-    e.preventDefault();
+    e.preventDefault();　//ボタンを一旦無効化
     //カード情報生成
     const card = {
       number: document.getElementById("card_number").value,
@@ -20,9 +20,10 @@ $(document).on('turbolinks:load', function() {
           $('<input hidden name="payjp-token">').val(response.id)
         ); //トークンを送信できるように隠しタグを生成
         document.inputForm.submit();
+      } else {
+        alert("カード情報が正しくありません。");
       }
     });
   });
-  false;
 });
 

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,9 +1,8 @@
-document.addEventListener(
-  "DOMContentLoaded", (e) => {
+$(document).on('turbolinks:load', function() {
     Payjp.setPublicKey("pk_test_0df3d3eb150a3f3dd0f2fc3e");
-    const btn = document.getElementById('token_submit'); //IDがtoken_submitの場合に取得されます
-    btn.addEventListener("click", (e) => {　//ボタンが押されたときに作動します
-      e.preventDefault();　//ボタンを一旦無効化します
+    const btn = document.getElementById('token_submit'); //IDがtoken_submitの場合に取得する
+    btn.addEventListener("click", (e) => {　//ボタンが押されたときに作動させる
+        e.preventDefault();　//ボタンを一旦無効化する
 
       //カード情報生成
       const card = {
@@ -11,15 +10,15 @@ document.addEventListener(
         cvc: document.getElementById("cvc").value,
         exp_month: document.getElementById("exp_month").value,
         exp_year: document.getElementById("exp_year").value
-      }; //入力されたデータを取得します。
+      }; //入力されたデータを取得する
 
-      //トークン生成
+      //cardトークン生成
       Payjp.createToken(card, (status, response) => {
-        if (status === 200) { //成功した場合
+        if (status === 200) { 
           $("#card_number").removeAttr("name");
           $("#cvc").removeAttr("name");
           $("#exp_month").removeAttr("name");
-          $("#exp_year").removeAttr("name"); //カード情報を自分のサーバにpostせず削除します
+          $("#exp_year").removeAttr("name"); //カード情報を自分のサーバにpostせず削除する
           $("#card_token").append(
             $('<input hidden name="payjp-token">').val(response.id)
           ); //トークンを送信できるように隠しタグを生成
@@ -30,4 +29,5 @@ document.addEventListener(
         }
       });
     });
-  },false);
+  false;
+});

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -48,9 +48,9 @@ class CardsController < ApplicationController
       )
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to card_path(@card.id)
+        redirect_to card_path(@card.id), notice: "クレジットカード情報を登録しました。"
       else
-        redirect_to action: "create"
+        redirect_to action: "create", notice: "クレジットカード情報が正しくありません。"
       end
     end
   end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -37,7 +37,7 @@ class CardsController < ApplicationController
   def create #PayjpとCardのデータベースを作成
     Payjp.api_key = Rails.application.credentials[:payjp][:PAYJP_PRIVATE_KEY]
     if params['payjp-token'].blank?
-      redirect_to action: "new"
+      redirect_to action: "new", alert: 'クレジットカード情報を入力してください。'
     else
       # トークンが正常に発行されていたら、顧客情報をPAY.JPに登録します。
       customer = Payjp::Customer.create(
@@ -48,9 +48,9 @@ class CardsController < ApplicationController
       )
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to card_path(@card.id), notice: "クレジットカード情報を登録しました。"
+        redirect_to card_path(@card.id), notice: 'クレジットカード情報を登録しました。'
       else
-        redirect_to action: "create", notice: "クレジットカード情報が正しくありません。"
+        redirect_to action: "new", alert: 'クレジットカード情報が正しくありません。'
       end
     end
   end
@@ -61,9 +61,9 @@ class CardsController < ApplicationController
     customer = Payjp::Customer.retrieve(@card.customer_id)
     customer.delete
     if @card.destroy #削除に成功した時にポップアップを表示します。
-      redirect_to action: "show", notice: "削除しました"
+      redirect_to action: "show", notice: '削除しました'
     else #削除に失敗した時にアラートを表示します。
-      redirect_to action: "show", alert: "削除できませんでした"
+      redirect_to action: "show", alert:  '削除できませんでした'
     end
   end
 

--- a/app/views/cards/_cards_create-page_show.html.haml
+++ b/app/views/cards/_cards_create-page_show.html.haml
@@ -13,13 +13,14 @@
             %ul.creditcard--info
               %li
                 .creditcard--info__form
-                  = image_tag "#{@card_src}",width:'34',height:'20', alt:'master-card'
+                  = image_tag "#{@card_src}",width:'34',height:'20', alt:'カード画像'
                   %p.creditcard--info__form__period
-                    = "**** **** **** " + @card_information.last4 #クレジットカードの下４桁を表示
+                    = "**** **** **** " + @card_information.last4 
                   %p.creditcard--info__form__period 
+                  有効期限:
                   - exp_month = @card_information.exp_month.to_s
                   - exp_year = @card_information.exp_year.to_s.slice(2,3)
-                  = exp_month + " / " + exp_year
+                  = exp_month + "/" + exp_year
                   = button_to "削除する", card_path(@card), method: :delete, class:"creditcard--info__form--delete"
         - else
           .link__btn


### PR DESCRIPTION
WHAT
consoleにずっと表示されているエラーの解消。
クレジットカード登録がリロードしないと登録出来ないので、その解決。
フラッシュメッセージをリダイレクト先で表示

WHY
クレジットカード登録にスムーズに行える様にするため。
ページの統一感を出すため。

プレビュー

![demo](https://gyazo.com/46dfe65ae341c010bf8083a928b8a8a7/raw)

![demo](https://gyazo.com/e4a64f1d9bfe3e90a408ea69cbc6dd06/raw)

![demo](https://gyazo.com/09a440977a04fb1e3e637437e04ec414/raw)