### PR TITLE
【サーバサイド】商品検索Lv1

### DIFF
--- a/app/assets/stylesheets/modules/_search-index.scss
+++ b/app/assets/stylesheets/modules/_search-index.scss
@@ -23,6 +23,7 @@
 
       &__itemBox {
         background-color: #fff;
+        max-width: 220px;
         margin: 0 20px 20px 20px;
         font-size: $itemIndex_font-size;
         position: relative;
@@ -41,7 +42,7 @@
         &--summary {
           padding: 16px 16px;
           .itemDetails {         
-            display:flex;
+            display: flex;
             justify-content: space-between;
 
             &__fav, &__view {

--- a/app/assets/stylesheets/modules/_search-index.scss
+++ b/app/assets/stylesheets/modules/_search-index.scss
@@ -18,8 +18,6 @@
       margin: 0 auto;
       display: flex;
       flex-wrap: wrap;
-      justify-content: flex-end;
-      flex-direction: row-reverse;
 
       &__itemBox {
         background-color: #fff;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -163,14 +163,14 @@ class ItemsController < ApplicationController
   
   def tag
     @tag = Tag.find_by(name: params[:name])
-    @items = @tag.items
+    @items = @tag.items.reverse
     @current_user_id = current_user.id if user_signed_in?
     @likes_count = Like.group(:item_id).count
   end
   
   def search
     @keyword = params[:keyword]
-    @items = Item.search(params[:keyword])
+    @items = Item.search(params[:keyword]).reverse
     @current_user_id = current_user.id if user_signed_in?
     @likes_count = Like.group(:item_id).count
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -167,10 +167,12 @@ class ItemsController < ApplicationController
     @current_user_id = current_user.id if user_signed_in?
     @likes_count = Like.group(:item_id).count
   end
-
+  
   def search
     @keyword = params[:keyword]
     @items = Item.search(params[:keyword])
+    @current_user_id = current_user.id if user_signed_in?
+    @likes_count = Like.group(:item_id).count
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -168,6 +168,11 @@ class ItemsController < ApplicationController
     @likes_count = Like.group(:item_id).count
   end
 
+  def search
+    @keyword = params[:keyword]
+    @items = Item.search(params[:keyword])
+  end
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -63,9 +63,9 @@ class Item < ApplicationRecord
     end
   end
 
-  def self.search(search)
-    return Item.all unless search
-    Item.where(['name LIKE ? OR explanation LIKE ?', "%#{search}%", "%#{search}%"])
+  def self.search(keyword)
+    return Item.all unless keyword
+    Item.where(['name LIKE ? OR explanation LIKE ?', "%#{keyword}%", "%#{keyword}%"])
   end
  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -62,5 +62,10 @@ class Item < ApplicationRecord
       item.tags.delete(id)
     end
   end
+
+  def self.search(search)
+    return Item.all unless search
+    Item.where(['name LIKE ? OR explanation LIKE ?', "%#{search}%", "%#{search}%"])
+  end
  
 end

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,15 @@
+%header
+  = render 'layouts/global-header'
+.searchResult
+  %section.searchIndex
+    .searchIndex__title
+      %h2 検索結果
+      %h3 <strong>検索ワード： #{@keyword}</strong>
+  
+    .searchIndex__contents
+      - @items.each do |item|
+        = item.name
+
+%footer
+  = render 'layouts/global-footer'
+= render 'layouts/global-sellBtn'

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -8,7 +8,35 @@
   
     .searchIndex__contents
       - @items.each do |item|
-        = item.name
+        - unless item.user_id == @current_user_id
+          = link_to item_path(item.id), class: 'searchIndex__contents__itemBox' do 
+            = image_tag item.pictures.first.image.url, class: 'searchIndex__contents__itemBox--image', alt: '商品画像'
+            - unless item.bought_at == nil
+              .searchIndex__contents__itemBox--triangle
+              .searchIndex__contents__itemBox--soldMessage sold
+            .searchIndex__contents__itemBox--summary{data: {itemid: item.id}}
+              %name 
+                = item.name
+              .itemDetails
+                .itemDetails__price 
+                  #{item.price}円
+                .itemDetails__fav
+                  .itemDetails__fav--mark
+                    = icon('fa','star')
+                  .itemDetails__fav--count
+                    - if @likes_count[item.id] == nil
+                      0
+                    - else
+                      = @likes_count[item.id]
+                .itemDetails__view
+                  .itemDetails__view--mark
+                    = icon('fa','eye')
+                  .itemDetails__view--count 
+                    - if item.view_count > 99999
+                      99999+
+                    - else
+                      = item.view_count
+              %p (税込)
 
 %footer
   = render 'layouts/global-footer'

--- a/app/views/layouts/_global-header.html.haml
+++ b/app/views/layouts/_global-header.html.haml
@@ -2,10 +2,13 @@
   .wrapper__top
     = link_to root_path, class: 'wrapper__top__icon' do 
       = image_tag 'logo.png', width: '140', alt: 'FURIMAロゴ'
-    .wrapper__top__searchBox
-      %input{ type: 'text', class: 'wrapper__top__searchBox__input', placeholder: 'キーワードから探す' }
-      = link_to '#', class: 'wrapper__top__searchBox__icon' do
-        = image_tag 'icon-search 1.png', alt: '検索ボタン'
+    = form_with url: search_items_path, class: 'wrapper__top__searchBox', method: :get, local: true do |f|
+      = f.text_field :keyword, class: 'wrapper__top__searchBox__input', placeholder: 'キーワードから探す'
+      = image_submit_tag 'icon-search 1.png', class: 'wrapper__top__searchBox__icon'
+    -# .wrapper__top__searchBox
+    -#   %input{ type: 'text', class: 'wrapper__top__searchBox__input', placeholder: 'キーワードから探す' }
+    -#   = link_to '#', class: 'wrapper__top__searchBox__icon' do
+    -#     = image_tag 'icon-search 1.png', alt: '検索ボタン'
 
   .wrapper__bottom
     %ul

--- a/app/views/layouts/_global-header.html.haml
+++ b/app/views/layouts/_global-header.html.haml
@@ -5,10 +5,6 @@
     = form_with url: search_items_path, class: 'wrapper__top__searchBox', method: :get, local: true do |f|
       = f.text_field :keyword, class: 'wrapper__top__searchBox__input', placeholder: 'キーワードから探す'
       = image_submit_tag 'icon-search 1.png', class: 'wrapper__top__searchBox__icon'
-    -# .wrapper__top__searchBox
-    -#   %input{ type: 'text', class: 'wrapper__top__searchBox__input', placeholder: 'キーワードから探す' }
-    -#   = link_to '#', class: 'wrapper__top__searchBox__icon' do
-    -#     = image_tag 'icon-search 1.png', alt: '検索ボタン'
 
   .wrapper__bottom
     %ul

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     collection do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
+      get 'search'
     end
     resources :users do
       resources :likes, only: [:create, :destroy]

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
  
 describe Item do
+  describe 'method' do
+    describe 'search(search) method' do
+      it 'キーワードを含むitemを検索できること' do
+        item = create(:item_valid)
+        searchItem = Item.search('商品')
+        expect(searchItem[0].id).to eq item.id
+      end
+      it 'キーワードを含むitemが存在しない場合は検索できないこと' do
+        item = create(:item_valid)
+        expect(Item.search('検索')).to eq []
+      end
+    end
+  end
+
   describe '#update' do
     let(:changed_str) {'編集'}
     let(:changed_int) {12345}

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,9 +3,14 @@ require 'rails_helper'
 describe Item do
   describe 'method' do
     describe 'search(search) method' do
-      it 'キーワードを含むitemを検索できること' do
+      it 'nameにキーワードを含むitemを検索できること' do
         item = create(:item_valid)
-        searchItem = Item.search('商品')
+        searchItem = Item.search('名')
+        expect(searchItem[0].id).to eq item.id
+      end
+      it 'explanationにキーワードを含むitemを検索できること' do
+        item = create(:item_valid)
+        searchItem = Item.search('説明')
         expect(searchItem[0].id).to eq item.id
       end
       it 'キーワードを含むitemが存在しない場合は検索できないこと' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,18 +2,16 @@ require 'rails_helper'
  
 describe Item do
   describe 'method' do
-    describe 'search(search) method' do
-      it 'nameにキーワードを含むitemを検索できること' do
+    describe 'search(keyword) method' do
+      it 'nameにkeywordを含むitemを検索できること' do
         item = create(:item_valid)
-        searchItem = Item.search('名')
-        expect(searchItem[0].id).to eq item.id
+        expect(Item.search('名')).to include item
       end
-      it 'explanationにキーワードを含むitemを検索できること' do
+      it 'explanationにkeywordを含むitemを検索できること' do
         item = create(:item_valid)
-        searchItem = Item.search('説明')
-        expect(searchItem[0].id).to eq item.id
+        expect(Item.search('説明')).to include item
       end
-      it 'キーワードを含むitemが存在しない場合は検索できないこと' do
+      it 'keywordを含むitemが存在しない場合は検索できないこと' do
         item = create(:item_valid)
         expect(Item.search('検索')).to eq []
       end


### PR DESCRIPTION
# What
あいまい検索機能を実装した。
- ページトップの検索窓からキーワードを入力して商品のあいまい検索ができる。
- キーワードが商品名か商品説明の文字列に含まれている場合、当てはまる商品一覧を表示する。
- ログインしていないユーザーも検索ができる。

# Why
ユーザーが検索したい商品を見つけやすくするため。

# Capture
[![Image from Gyazo](https://i.gyazo.com/7414084fd9189ce86bd5ef465bbc2013.gif)](https://gyazo.com/7414084fd9189ce86bd5ef465bbc2013)
キャプチャ1

[![Image from Gyazo](https://i.gyazo.com/2eaf805b9a70b129ef7deeacb96ab544.gif)](https://gyazo.com/2eaf805b9a70b129ef7deeacb96ab544)
キャプチャ2

[![Image from Gyazo](https://i.gyazo.com/367172158bbbc045bf02eb16434ce701.gif)](https://gyazo.com/367172158bbbc045bf02eb16434ce701)
キャプチャ3

[![Image from Gyazo](https://i.gyazo.com/88ebd558fb39d894bdcacbe28e4e4a84.png)](https://gyazo.com/88ebd558fb39d894bdcacbe28e4e4a84)
キャプチャ4（テスト結果）