### PR TITLE
fix_comment_error-message

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -60,7 +60,7 @@ $(document).on('turbolinks:load', function() {
     $('.comment__container__list').animate({ scrollTop: $('.comment__container__list')[0].scrollHeight});
   })
   .fail(function() {
-    alert("メッセージ送信に失敗しました");
+    alert("コメントを入力してください。");
       })
   .always(function() {
     $('.submit__btn').removeAttr('disabled');

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,15 +9,15 @@ class CommentsController < ApplicationController
     if @comment.save
       respond_to do |format|
         format.json
-      end
-     else
+    end
+    else
       flash[:alert] = 'コメント出来ませんでした。'
-      end
+    end
   end
 
   def update
     comment = Comment.find(params[:id])
-    comment.text = 'このコメントは出品者によって削除されました。'
+    comment.text =  'このコメントは出品者によって削除されました。'
     comment.comment_status = 1
     comment.save
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,8 +11,7 @@ class CommentsController < ApplicationController
         format.json
       end
      else
-       flash[:alert] = 'コメント出来ませんでした。'
-       redirect_to item_path(@comment.item_id)
+      flash[:alert] = 'コメント出来ませんでした。'
       end
   end
 


### PR DESCRIPTION
WHAT
コメントのエラーメッセージの修正

WHY
コメント投稿を失敗し、他のページに移動すると移動先のページでエラ〜メッセージが表示される。

プレビュー

![demo](https://gyazo.com/3dc92a0184ae273c8960a9b1039a6ed7/raw)